### PR TITLE
User name mapping

### DIFF
--- a/src/assign-to-issue.ts
+++ b/src/assign-to-issue.ts
@@ -4,29 +4,7 @@ import fetch from 'node-fetch';
 import * as qs from 'querystring';
 
 import { Config } from './config';
-
-const fetchSlackUserList = (token: string): Promise<Map<string, string>> => {
-  interface SlackUser {
-    id: string;
-    name: string;
-  }
-  interface SlackUserList {
-    members: SlackUser[];
-    ok: boolean;
-  }
-  const body = JSON.stringify({ token });
-  const headers = { 'Content-Type': 'application/json' };
-  const method = 'POST';
-  const url = 'https://slack.com/api/users.list';
-  return fetch(url, { body, headers, method })
-    .then((response) => response.json())
-    .then(({ members, ok }: SlackUserList) =>
-      ok ? Promise.resolve(members) : Promise.reject(new Error('ok is false')))
-    .then((members: SlackUser[]) =>
-      members.reduce(
-        (map: Map<string, string>, { id, name }) => map.set(id, name),
-        new Map<string, string>()));
-};
+import { fetchUserList as fetchSlackUserList } from './slack';
 
 // Hear @XXX review YYY#ZZZ and assign to issue
 const assignToIssue = (

--- a/src/assign-to-issue.ts
+++ b/src/assign-to-issue.ts
@@ -5,6 +5,29 @@ import * as qs from 'querystring';
 
 import { Config } from './config';
 
+const fetchSlackUserList = (token: string): Promise<Map<string, string>> => {
+  interface SlackUser {
+    id: string;
+    name: string;
+  }
+  interface SlackUserList {
+    members: SlackUser[];
+    ok: boolean;
+  }
+  const body = JSON.stringify({ token });
+  const headers = { 'Content-Type': 'application/json' };
+  const method = 'POST';
+  const url = 'https://slack.com/api/users.list';
+  return fetch(url, { body, headers, method })
+    .then((response) => response.json())
+    .then(({ members, ok }: SlackUserList) =>
+      ok ? Promise.resolve(members) : Promise.reject(new Error('ok is false')))
+    .then((members: SlackUser[]) =>
+      members.reduce(
+        (map: Map<string, string>, { id, name }) => map.set(id, name),
+        new Map<string, string>()));
+};
+
 // Hear @XXX review YYY#ZZZ and assign to issue
 const assignToIssue = (
   {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,28 @@
+import * as fs from 'fs';
+
+type GitHubUsername = string;
+type SlackUsername = string;
+type GitHubUsers = Map<SlackUsername, GitHubUsername>;
+
 interface Config {
   accessToken: string;
   githubPass: string;
   githubTeam: string;
   githubUsername: string;
+  githubUsernames: GitHubUsers;
   verificationToken: string;
 }
+
+const loadGitHubUsernames = (): Map<SlackUsername, GitHubUsername> => {
+  const jsonString = fs.readFileSync('./users.json', { encoding: 'utf8' });
+  const users: { [slack: string]: string; } = JSON.parse(jsonString);
+  return new Map(
+    Object
+      .keys(users)
+      .map((slack: string): [string, string] => {
+        return [slack, users[slack]];
+      }));
+};
 
 const initConfig = (): Config => {
   return {
@@ -12,6 +30,7 @@ const initConfig = (): Config => {
     githubPass: process.env.NODE_GITHUB_PASS,
     githubTeam: process.env.NODE_GITHUB_TEAM,
     githubUsername: process.env.NODE_GITHUB_USERNAME,
+    githubUsernames: loadGitHubUsernames(),
     verificationToken: process.env.NODE_SLACK_VERIFICATION
   };
 };

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -1,0 +1,26 @@
+import fetch from 'node-fetch';
+
+const fetchUserList = (token: string): Promise<Map<string, string>> => {
+  interface SlackUser {
+    id: string;
+    name: string;
+  }
+  interface SlackUserList {
+    members: SlackUser[];
+    ok: boolean;
+  }
+  const body = JSON.stringify({ token });
+  const headers = { 'Content-Type': 'application/json' };
+  const method = 'POST';
+  const url = 'https://slack.com/api/users.list';
+  return fetch(url, { body, headers, method })
+    .then((response) => response.json())
+    .then(({ members, ok }: SlackUserList) =>
+      ok ? Promise.resolve(members) : Promise.reject(new Error('ok is false')))
+    .then((members: SlackUser[]) =>
+      members.reduce(
+        (map: Map<string, string>, { id, name }) => map.set(id, name),
+        new Map<string, string>()));
+};
+
+export { fetchUserList };

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -23,4 +23,26 @@ const fetchUserList = (token: string): Promise<Map<string, string>> => {
         new Map<string, string>()));
 };
 
-export { fetchUserList };
+const postMessage = (
+  token: string,
+  channel: string,
+  text: string
+): Promise<void> => {
+  interface SlackPostMessage {
+    ok: boolean;
+  }
+  const body = JSON.stringify({
+    channel,
+    text,
+    token
+  });
+  const headers = { 'Content-Type': 'application/json' };
+  const method = 'POST';
+  const url = 'https://slack.com/api/chat.postMessage';
+  return fetch(url, { body, headers, method })
+    .then((response) => response.json())
+    .then(({ ok }: SlackPostMessage) =>
+      ok ? Promise.resolve(void 0) : Promise.reject(new Error('ok is false')));
+};
+
+export { fetchUserList, postMessage };

--- a/test/assign-to-issue-test.ts
+++ b/test/assign-to-issue-test.ts
@@ -10,24 +10,21 @@ describe('assignToIssue', () => {
   let assignToIssue: typeof assignToIssueT;
   let authenticate: sinon.SinonStub;
   let addAssigneesToIssue: sinon.SinonStub;
-  let fetch: sinon.SinonStub;
   let fetchUserList: sinon.SinonStub;
-  let postMessageJson: sinon.SinonStub;
+  let postMessage: sinon.SinonStub;
 
   beforeEach(() => {
     authenticate = sinon.stub();
     addAssigneesToIssue = sinon.stub().returns(Promise.resolve());
-    postMessageJson = sinon.stub().returns(Promise.resolve());
-    fetch = sinon.stub().returns(Promise.resolve({ json: postMessageJson }));
     fetchUserList = sinon.stub()
       .returns(Promise.resolve(new Map([['tadaSlackId', 'tadaSlack']])));
+    postMessage = sinon.stub().returns(Promise.resolve());
     assignToIssue = proxyquire('../src/assign-to-issue', {
-      './slack': { fetchUserList },
+      './slack': { fetchUserList, postMessage },
       'github': function GitHubApi() {
         this.authenticate = authenticate;
         this.issues = { addAssigneesToIssue };
-      },
-      'node-fetch': { default: fetch }
+      }
     }).assignToIssue;
   });
 
@@ -50,9 +47,8 @@ describe('assignToIssue', () => {
         assert(addAssigneesToIssue.callCount === 1);
         assert(addAssigneesToIssue.getCall(0).args[0]
           .assignees === 'tadaGitHub');
-        assert(postMessageJson.callCount === 1);
-        assert(fetch.callCount === 1);
-        assert((fetch.getCall(0).args[0] as string).startsWith('https:'));
+        assert(postMessage.callCount === 1);
+        assert(postMessage.getCall(0).args[0] === 'ACCESS_TOKEN');
         assert(fetchUserList.callCount === 1);
         assert(fetchUserList.getCall(0).args[0] === 'ACCESS_TOKEN');
       });

--- a/test/assign-to-issue-test.ts
+++ b/test/assign-to-issue-test.ts
@@ -10,14 +10,20 @@ describe('assignToIssue', () => {
   let assignToIssue: typeof assignToIssueT;
   let authenticate: sinon.SinonStub;
   let addAssigneesToIssue: sinon.SinonStub;
-  let json: sinon.SinonStub;
   let fetch: sinon.SinonStub;
+  let postMessageJson: sinon.SinonStub;
+  let userListJson: sinon.SinonStub;
 
   beforeEach(() => {
     authenticate = sinon.stub();
     addAssigneesToIssue = sinon.stub().returns(Promise.resolve());
-    json = sinon.stub().returns(Promise.resolve());
-    fetch = sinon.stub().returns(Promise.resolve({ json }));
+    postMessageJson = sinon.stub().returns(Promise.resolve());
+    userListJson = sinon.stub().returns(Promise.resolve({
+      members: [{ id: 'tadaSlackId', name: 'tadaSlack' }], ok: true
+    }));
+    fetch = sinon.stub();
+    fetch.onCall(0).returns(Promise.resolve({ json: userListJson }));
+    fetch.onCall(1).returns(Promise.resolve({ json: postMessageJson }));
     assignToIssue = proxyquire('../src/assign-to-issue', {
       'github': function GitHubApi() {
         this.authenticate = authenticate;
@@ -32,20 +38,23 @@ describe('assignToIssue', () => {
       {
         githubPass: 'PASS',
         githubTeam: 'TEAM',
-        githubUsername: 'USER'
+        githubUsername: 'USER',
+        githubUsernames: new Map([['tadaSlack', 'tadaGitHub']])
       } as Config, // FIXME
       {
         bot_id: false,
-        text: '@tada assign sususu-shi#1'
+        text: '@tadaSlackId assign sususu-shi#1'
       }).then((value) => {
         assert(value === null);
         assert(authenticate.callCount === 1);
         assert(authenticate.getCall(0).args[0].type === 'basic');
         assert(addAssigneesToIssue.callCount === 1);
-        assert(addAssigneesToIssue.getCall(0).args[0].assignees === 'tada');
-        assert(json.callCount === 1);
-        assert(fetch.callCount === 1);
-        assert((fetch.getCall(0).args[0] as string).startsWith('https:'));
+        assert(addAssigneesToIssue.getCall(0).args[0]
+          .assignees === 'tadaGitHub');
+        assert(postMessageJson.callCount === 1);
+        assert(fetch.callCount === 2);
+        assert((fetch.getCall(0).args[0] as string).endsWith('users.list'));
+        assert((fetch.getCall(1).args[0] as string).startsWith('https:'));
       });
   });
 });

--- a/test/slack-test.ts
+++ b/test/slack-test.ts
@@ -1,0 +1,37 @@
+import * as assert from 'assert';
+import * as mocha from 'mocha';
+import * as proxyquire from 'proxyquire';
+import * as sinon from 'sinon';
+
+import { fetchUserList as fetchUserListT } from '../src/slack';
+
+describe('slack.fetchUserList', () => {
+  let fetchUserList: typeof fetchUserListT;
+  let fetch: sinon.SinonStub;
+  let userListJson: sinon.SinonStub;
+
+  beforeEach(() => {
+    userListJson = sinon.stub().returns(Promise.resolve({
+      members: [{ id: 'tadaSlackId', name: 'tadaSlack' }], ok: true
+    }));
+    fetch = sinon.stub();
+    fetch.onCall(0).returns(Promise.resolve({ json: userListJson }));
+    fetchUserList = proxyquire('../src/slack', {
+      'node-fetch': { default: fetch }
+    }).fetchUserList;
+  });
+
+  it('works', () => {
+    return fetchUserList('token1')
+      .then((userList) => {
+        assert(userList.size === 1);
+        assert(userList.get('tadaSlackId') === 'tadaSlack');
+        assert(fetch.callCount === 1);
+        const call = fetch.getCall(0);
+        assert(call.args[0] === 'https://slack.com/api/users.list');
+        assert(call.args[1].body === JSON.stringify({ token: 'token1' }));
+        assert(call.args[1].method === 'POST');
+        assert(call.args[1].headers['Content-Type'] === 'application/json');
+      });
+  });
+});


### PR DESCRIPTION
- Slack User ID <-> User Name のマッピングに対応しました。
- 設定ファイルから Slack User Name <-> GitHub User Name のマッピングを読み込むようにしました。
- `found[n]` の形で使いまわされていたものに名前を付けました。
- Slack の API 呼び出しを `slack` モジュールに抽出しました。

実際に動作するか分からない（デプロイしていない）ので、試してみてください。 slack の accessToken に適切な権限が設定されていないと動作しないと思います。 https://api.slack.com/methods/users.list

`slack` モジュールと同様に `github` モジュールとして GitHub の API 呼び出しを抽出してみてください。おそらく test での mock が楽になります。